### PR TITLE
Update ddos-gen.py

### DIFF
--- a/ddos-gen.py
+++ b/ddos-gen.py
@@ -375,7 +375,13 @@ for x in range(0,args.subs):
               src_mac   = str(RandMAC())
               print "new mac choosen ", src_mac
            else:
-               src_mac   = args.smac
+               # make sure the static mac is only incremented with each subscriber and not with each source per subscriber
+               # first create integer out of the mac-address
+               mac   = EUI(args.smac) # EUI('22-22-33-33-44-45')
+               int_mac = int(mac) +x  # now an interger: 37530283230278
+               src_mac_eui   = EUI(int_mac) # again EUi format: EUI('22-22-33-33-44-46')
+               src_mac_eui.dialect = mac_unix_expanded # EUI('22:22:33:33:44:46')
+               src_mac=str(src_mac_eui)
 
 	   if args.vid <> 'False':
 	       # packets are either tagged or double-tagged


### PR DESCRIPTION
changed how the src-mac are beeing choosen in case static smac is configured.
if static configured, then each subscriber-line used a single random mac-address for all packets generated
thanks

christian
